### PR TITLE
Add tag to checkout action

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
+        ref: ${{ matrix.tag }}
 
     - name: Build Image
       id: build-image


### PR DESCRIPTION
Dieser PR fügt den Tag zur Checkout Action hinzu anstatt main auszuchecken.